### PR TITLE
Clients now use absolute image path

### DIFF
--- a/data/clients/antishop.yaml
+++ b/data/clients/antishop.yaml
@@ -1,3 +1,3 @@
 name: "Antishop"
-image: "img/clients/antishop.png"
+image: "/img/clients/antishop.png"
 url: "https://antishop.fi/"

--- a/data/clients/boudlerpaja.yaml
+++ b/data/clients/boudlerpaja.yaml
@@ -1,3 +1,3 @@
 name: "Jyväskylän kiipeilykeskus"
-image: "img/clients/boulder.png"
+image: "/img/clients/boulder.png"
 url: "https://www.jyväskylänkiipeilykeskus.fi/"

--- a/data/clients/ceili.yaml
+++ b/data/clients/ceili.yaml
@@ -1,3 +1,3 @@
 name: "Ceili"
-image: "img/clients/ceili-logo.png"
+image: "/img/clients/ceili-logo.png"
 url: "https://www.ceili.fi/"

--- a/data/clients/delorean.yaml
+++ b/data/clients/delorean.yaml
@@ -1,3 +1,3 @@
 name: "DeLorean"
-image: "img/clients/delorean.png"
+image: "/img/clients/delorean.png"
 url: "https://deloreanjkl.fi/"

--- a/data/clients/esc.yaml
+++ b/data/clients/esc.yaml
@@ -1,3 +1,3 @@
 name: "Club Escape"
-image: "img/clients/Escape-ESC-logo-musta.png"
+image: "/img/clients/Escape-ESC-logo-musta.png"
 url: "https://escapejkl.fi/"

--- a/data/clients/helmi.yaml
+++ b/data/clients/helmi.yaml
@@ -1,3 +1,3 @@
 name: "Helmi Karaoke Bar"
-image: "img/clients/helmi-logo-nettisivut-musta.png"
+image: "/img/clients/helmi-logo-nettisivut-musta.png"
 url: "https://www.helmibar.fi/"

--- a/data/clients/huoltokukko.yaml
+++ b/data/clients/huoltokukko.yaml
@@ -1,3 +1,3 @@
 name: "Huoltokukko"
-image: "img/clients/huoltokukko.png"
+image: "/img/clients/huoltokukko.png"
 url: "https://huoltokukko.fi/"

--- a/data/clients/jamix.yaml
+++ b/data/clients/jamix.yaml
@@ -1,3 +1,3 @@
 name: "Jamix"
-image: "img/clients/jamix_200.png"
+image: "/img/clients/jamix_200.png"
 url: "https://www.jamix.com/"

--- a/data/clients/konehuone.yaml
+++ b/data/clients/konehuone.yaml
@@ -1,3 +1,3 @@
 name: "Konehuone"
-image: "img/clients/konehuone.png"
+image: "/img/clients/konehuone.png"
 url: "https://parturikonehuone.fi/"

--- a/data/clients/loimu.yaml
+++ b/data/clients/loimu.yaml
@@ -1,3 +1,3 @@
 name: "Loimu"
-image: "img/clients/loimu-vaaka-värillinen.png"
+image: "/img/clients/loimu-vaaka-värillinen.png"
 url: "https://www.loimu.fi"

--- a/data/clients/teerenpeli.yaml
+++ b/data/clients/teerenpeli.yaml
@@ -1,3 +1,3 @@
 name: "Teerenpeli"
-image: "img/clients/teerenpeli.png"
+image: "/img/clients/teerenpeli.png"
 url: "https://www.teerenpeli.com/"

--- a/data/clients/wapice.yaml
+++ b/data/clients/wapice.yaml
@@ -1,3 +1,3 @@
 name: "Wapice"
-image: "img/clients/wapice.png"
+image: "/img/clients/wapice.png"
 url: "https://www.wapice.com/"


### PR DESCRIPTION
The problem was that the english site didn't generate to the public root so the relative path I had mistakenly used while defining the clients didn't work.