### PR TITLE
remove column div from calendar

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -5,10 +5,7 @@ description = ""
 
 ### Linkki Jyväskylä ry, eli puhekielessä Linkki on vuonna 2006 perustettu Jyväskylän yliopiston informaatioteknologian tiedekunnassa toimiva tietotekniikan, tietojenkäsittelytieteen ja koulutusteknologian pääaine-, sivuaine- sekä jatko-opiskelijoiden ainejärjestö.
 
-{{< column width=9 >}}
 {{< google_calendar
 "Y19nMmVxdDJhN3UxZmMxcGFoZTJvMGVjbTdhc0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t"
 >}}
-{{< /column >}}
-
 {{< button "Tilaa kalenteri" "https://calendar.google.com/calendar/u/2?cid=Y19nMmVxdDJhN3UxZmMxcGFoZTJvMGVjbTdhc0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t" >}}


### PR DESCRIPTION
Removed unnecessary column div wrapping the calendar, this would cause the structure to unravel on bigger screens.
Fixes #98 