### PR TITLE
English urls

### DIFF
--- a/content/hallitus/2024/index.en.md
+++ b/content/hallitus/2024/index.en.md
@@ -4,6 +4,7 @@ date = "2024-01-01T00:00:00+02:00"
 authors = ["Santeri Sormunen", "Oskari Lahtinen", "Lassi Karjalainen", "Vili Kärkkäinen", "Ossi Rantala", "Valtteri Hiltunen", "Viljami Töhönen", "Juho Kallijärvi", "Emma Järvinen", "Jami Virtanen", "Pekka Pihjalamaa", "Mortti Luhtala", "Aleksi Sulasalmi", "Jules Kuortti", "Veeti Kataja", "Jenna Tykkyläinen", "Veikko Havula", "Aina Seppänen", "Aino Sipola", "Johannes Horila", "Taru Nikkanen", "Toni Pietiläinen", "Jaakko Siika-aho", "Juho Ropanen", "Alexander Goldhill", "Lari Nurkka"]
 banner = "/img/hallitukset/hallitus2024.jpg"
 summary = " "
+url = "board/2024"
 +++
 
 # Administrative team

--- a/content/hallitus/_index.en.md
+++ b/content/hallitus/_index.en.md
@@ -1,7 +1,8 @@
 +++
-title = "Board of Directors"
-description = "All boards of directors of Linkki Jyväskylä ry"
+title = "Board"
+description = "All boards of Linkki Jyväskylä ry"
 keywords = ["board"]
+url = "board"
 +++
 
 A **board of directors** is chosen for a year at a time in the organisation's autumn meeting, where all members of the organisation are invited to vote. Board members do not differ from other members beside their obligation to fulfill operations required by law and the operative plan of the organisation. In Linkki, members acting in administrative roles or as directors of teams are members of the board.

--- a/content/toiminta/haalarimerkit/index.en.md
+++ b/content/toiminta/haalarimerkit/index.en.md
@@ -2,12 +2,13 @@
 title = "Overall patches"
 description = ""
 keywords = ["overall", "patch", "patches"]
+url = "activities/overall-patches"
 +++
 
 # Overall patches sold by Linkki
 
 Get your own from [Kattila](/toiminta/kattila)!
-Available payment methods are Mobilepay and card payment. 1 pcs 3€ and 2pcs 5€ .
+Available payment methods are Mobilepay and card payment. 1pcs 3€ and 2pcs 5€ .
 
 {{< row >}}
 {{< column width=4 >}}

--- a/content/toiminta/kattila/index.en.md
+++ b/content/toiminta/kattila/index.en.md
@@ -2,6 +2,7 @@
 title = "Kattila"
 description = "subject association space"
 keywords = ["kattila", "subject association space"]
+url = "activities/kattila"
 +++
 
 {{< row >}}

--- a/content/toiminta/keskustelukanavat.en.md
+++ b/content/toiminta/keskustelukanavat.en.md
@@ -1,7 +1,8 @@
 +++
-title = "Chats"
+title = "Chat"
 description = ""
 keywords = ["chat", "telegram", "irc", "matrix"]
+url = "activities/chat"
 +++
 
 

--- a/content/toiminta/tapahtumat.en.md
+++ b/content/toiminta/tapahtumat.en.md
@@ -2,6 +2,7 @@
 title = "Events"
 description = ""
 keywords = ["events", "calendar", "jyväsmetro", "metro", "instanssi", "boardgames", "crafts club", "book club"]
+url = "activities/events"
 +++
 
 # Jyväsmetro
@@ -32,7 +33,7 @@ Our skilled regulars are happy to help you with your projects, should you be int
 
 # Book Club
 
-Avid readers of Linkki gather together monthly to discuss a predetermined book and its themes. Read more on the Book Club [homepage](/toiminta/lukupiiri).
+Avid readers of Linkki gather together monthly to discuss a predetermined book and its themes. Read more on the Book Club [homepage](/en/activities/book-club).
 
 # Event calendar
 {{< google_calendar "Y19nMmVxdDJhN3UxZmMxcGFoZTJvMGVjbTdhc0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t" >}}

--- a/content/toiminta/tenttiarkisto.en.md
+++ b/content/toiminta/tenttiarkisto.en.md
@@ -2,10 +2,11 @@
 title = "Exam Archive"
 description = ""
 keywords = ["exam", "archive"]
+url = "activities/exam-archive"
 +++
 
 **Linkki Jyväskylä ry** maintains an exam archive of Mathematical Information
-Technology exams. It can be found physically from [Kattila](/toiminta/kattila) and
+Technology exams. It can be found physically from [Kattila](/en/activities/kattila) and
 scanned into a digital format in
 [this Drive share](https://drive.google.com/drive/folders/12xb5iER3Q23gaUnsyD_wJkzK056ijSs3).
 

--- a/content/toiminta/vuokraus/index.en.md
+++ b/content/toiminta/vuokraus/index.en.md
@@ -2,6 +2,7 @@
 title = "Equipment Rental"
 description = ""
 keywords = ["rental"]
+url = "activities/equipment-rental"
 +++
 
 

--- a/content/yhdistys/jäsenyys.en.md
+++ b/content/yhdistys/jäsenyys.en.md
@@ -2,6 +2,7 @@
 title = "Membership"
 description = "Membership"
 keywords = ["membership", "member", "benefits", "member benefits", "membership form"]
+url = "association/membership"
 +++
 
 {{< table-of-contents end=2 >}}

--- a/content/yhdistys/pöytäkirjat.en.md
+++ b/content/yhdistys/pöytäkirjat.en.md
@@ -2,6 +2,7 @@
 title = "Board minutes"
 description = "Board meeting minutes of Linkki Jyväskylä ry"
 keywords = ["minutes"]
+url = "association/minutes"
 +++
 
 You can find board meeting minutes of Linkki from [this drive directory](https://drive.google.com/drive/folders/1SQM7NyKDSB852xxHQQS8dt0_gB815abX).

--- a/content/yhdistys/säännöt/index.en.md
+++ b/content/yhdistys/säännöt/index.en.md
@@ -2,6 +2,7 @@
 title = "Rules and Guides"
 description = "Rules and guides"
 keywords = ["rules", "guides"]
+url = "association/rules"
 +++
 
 Unfortunately we don't have the resources to translate all our rules and guides
@@ -13,7 +14,7 @@ and the best of hopes in understanding it.
 
 # Wesite Information Policy
 
-The web page of Linkki Jyväskylä ry ([linkkijkl.fi]()) does not collect any data from its usage.
+The web page of Linkki Jyväskylä ry ([linkkijkl.fi]()) does not collect user data.
 
 
 # JYY’s Principles of a Safer Space

--- a/content/yhteistyö.en.md
+++ b/content/yhteistyö.en.md
@@ -2,6 +2,7 @@
 title = "Collaboration"
 description = ""
 keywords = ["company", "collaboration"]
+url = "collaboration"
 +++
 
 **Linkki Jyväskylä ry**, Linkki is a sizable student association for

--- a/hugo.toml
+++ b/hugo.toml
@@ -176,15 +176,15 @@ home = ["html", "rss", "api-sponsors"]
 [[languages.en.menus.main]]
     name = "Rules and guides"
     identifier = "menu.saannot"
-    url = "/en/yhdistys/säännöt/"
+    url = "/en/association/rules/"
     parent = "menu.yhdistys"
     weight = 1
 
 
 [[languages.en.menus.main]]
-    name = "Board of Directors"
+    name = "Board"
     identifier = "menu.hallitus"
-    url = "/en/hallitus/"
+    url = "/en/board/"
     parent = "menu.yhdistys"
     weight = 2
 
@@ -200,7 +200,7 @@ home = ["html", "rss", "api-sponsors"]
 [[languages.en.menus.main]]
     name = "Membership"
     identifier = "menu.jäsenyys"
-    url = "/en/yhdistys/jäsenyys/"
+    url = "/en/association/membership/"
     parent = "menu.yhdistys"
     weight = 4
 
@@ -208,7 +208,7 @@ home = ["html", "rss", "api-sponsors"]
 [[languages.en.menus.main]]
     name = "Board Minutes"
     identifier = "menu.pöytäkirjat"
-    url = "/en/yhdistys/pöytäkirjat/"
+    url = "/en/association/minutes/"
     parent = "menu.yhdistys"
     weight = 7
 
@@ -222,7 +222,7 @@ home = ["html", "rss", "api-sponsors"]
 [[languages.en.menus.main]]
     name = "Events"
     identifier = "menu.tapahtumat"
-    url = "/en/toiminta/tapahtumat/"
+    url = "/en/activities/events/"
     parent = "menu.toiminta"
     weight = 1
 
@@ -230,7 +230,7 @@ home = ["html", "rss", "api-sponsors"]
 [[languages.en.menus.main]]
     name = "Kattila"
     identifier = "menu.kattila"
-    url = "/en/toiminta/kattila/"
+    url = "/en/activities/kattila/"
     parent = "menu.toiminta"
     weight = 2
 
@@ -238,7 +238,7 @@ home = ["html", "rss", "api-sponsors"]
 [[languages.en.menus.main]]
     name = "Exam Archive"
     identifier = "menu.tenttiarkisto"
-    url = "/en/toiminta/tenttiarkisto/"
+    url = "/en/activities/exam-archive/"
     parent = "menu.toiminta"
     weight = 3
 
@@ -246,7 +246,7 @@ home = ["html", "rss", "api-sponsors"]
 [[languages.en.menus.main]]
     name = "Equipment Rental"
     identifier = "menu.vuokraus"
-    url = "/en/toiminta/vuokraus/"
+    url = "/en/activities/equipment-rental/"
     parent = "menu.toiminta"
     weight = 4
 
@@ -254,15 +254,15 @@ home = ["html", "rss", "api-sponsors"]
 [[languages.en.menus.main]]
     name = "Overall Patches"
     identifier = "menu.haalarimerkit"
-    url = "/en/toiminta/haalarimerkit/"
+    url = "/en/activities/overall-patches/"
     parent = "menu.toiminta"
     weight = 5
 
 
 [[languages.en.menus.main]]
-    name = "Chats"
+    name = "Chat"
     identifier = "menu.keskustelukanavat"
-    url = "/en/toiminta/keskustelukanavat/"
+    url = "/en/activities/chat/"
     parent = "menu.toiminta"
     weight = 6
 
@@ -270,7 +270,7 @@ home = ["html", "rss", "api-sponsors"]
 [[languages.en.menus.main]]
     name = "Collaboration"
     identifier = "menu.yhteistyö"
-    url = "/en/yhteistyö/"
+    url = "/en/collaboration/"
     weight = 4
 
 
@@ -330,11 +330,11 @@ home = ["html", "rss", "api-sponsors"]
 
 [languages.en.params]
     about_us = """
-            <a class="text-uppercase" href="/yhdistys/säännöt/#jäsenrekisteriseloste">
+            <a class="text-uppercase" href="/en/association/rules">
                 <strong>Privacy policy</strong>
             </a>
             <br/>
-            <a class="text-uppercase" href="/yhdistys/säännöt/">
+            <a class="text-uppercase" href="/en/association/rules">
                 <strong>Rules</strong>
             </a>
     """


### PR DESCRIPTION
Correct URLs for English transated content. For example, `/en/yhdistys/säännöt/` will become `/en/association/rules/`.

Also re-translated "Board of Directors" to "Board".