### PR TITLE
Carousel update

### DIFF
--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -3,7 +3,7 @@ title = "Linkki Jyväskylä ry"
 description = ""
 +++
 
-### Linkki Jyväskylä ry, Linkki is a sizeable student association for Mathematical Information Technology, and Educational Technology majors and minors in University of Jyväskylä. Association was founded back in 2006 and it operates in the Faculty of Information Technology, within the [Student Union of the University of Jyväskylä](https://jyy.fi/en/student-union-university-jyvaskyla/).
+<!-- ### Linkki Jyväskylä ry, Linkki is a sizeable student association for Mathematical Information Technology, and Educational Technology majors and minors in University of Jyväskylä. Association was founded back in 2006 and it operates in the Faculty of Information Technology, within the [Student Union of the University of Jyväskylä](https://jyy.fi/en/student-union-university-jyvaskyla/). -->
 
 {{< google_calendar "Y19nMmVxdDJhN3UxZmMxcGFoZTJvMGVjbTdhc0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t" >}}
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -3,7 +3,7 @@ title = "Linkki Jyväskylä ry"
 description = ""
 +++
 
-### Linkki Jyväskylä ry, eli puhekielessä Linkki on vuonna 2006 perustettu Jyväskylän yliopiston informaatioteknologian tiedekunnassa toimiva tietotekniikan, tietojenkäsittelytieteen ja koulutusteknologian pääaine-, sivuaine- sekä jatko-opiskelijoiden ainejärjestö.
+<!-- ### Linkki Jyväskylä ry, eli puhekielessä Linkki on vuonna 2006 perustettu Jyväskylän yliopiston informaatioteknologian tiedekunnassa toimiva tietotekniikan, tietojenkäsittelytieteen ja koulutusteknologian pääaine-, sivuaine- sekä jatko-opiskelijoiden ainejärjestö. -->
 
 {{< google_calendar
 "Y19nMmVxdDJhN3UxZmMxcGFoZTJvMGVjbTdhc0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t"

--- a/data/en/carousel/fresh.yaml
+++ b/data/en/carousel/fresh.yaml
@@ -4,3 +4,4 @@ description: >
   <p>Take a look at our guide for new students.</p>
 image: "img/linkkiukkeli-perus-istuu.webp"
 href: "/fuksit/"
+hide: true

--- a/data/en/carousel/new-sites.yaml
+++ b/data/en/carousel/new-sites.yaml
@@ -1,9 +1,6 @@
 weight: 1
-title: "New and shiny linkkijkl.fi"
+title: "Linkki's website"
 description: >
-  <p>Welcome!<br/>
-  <br/>
-  All feedback is appreciated.<br/>
-  The <a href="/en/hallitus/nykyinen#webmaster">association's webmaster</a> can direct it to our website team.</p>
+  <p>Linkki Jyväskylä ry is a student association for Mathematical Information Technology and Educational Technology students. 
 image: "img/linkki.svg"
 #href: "https://ayy.lmao"

--- a/data/en/carousel/room-for-improvement.yaml
+++ b/data/en/carousel/room-for-improvement.yaml
@@ -1,4 +1,4 @@
-weight: 3
+weight: 100
 title: "Room for improvement?"
 description: >
   <p>The sources for this page can be found under Linkki's GitHub account.

--- a/data/en/carousel/ytp.yaml
+++ b/data/en/carousel/ytp.yaml
@@ -1,0 +1,8 @@
+weight: 10
+title: "ATK-YTP 2024"
+description: >
+  <p>ATK-YTP will soon fill Jyväskylä with computer science students from all over Finland. Click for more info.
+  <br/><br/>
+  🌴 zyn zyn zyn 🌴</p>
+image: "/img/atk-ytp-2024.webp"
+href: "https://atk-ytp.org/en"

--- a/data/fi/carousel/fuksi.yaml
+++ b/data/fi/carousel/fuksi.yaml
@@ -4,3 +4,4 @@ description: >
   <p>Katso täältä uuden opiskelijan opas.</p>
 image: "img/linkkiukkeli-perus-istuu.webp"
 href: "/fuksit/"
+hide: true

--- a/data/fi/carousel/parantamisen-varaa.yaml
+++ b/data/fi/carousel/parantamisen-varaa.yaml
@@ -1,4 +1,4 @@
-weight: 3
+weight: 100
 title: "Parantamisen varaa?"
 description: >
   <p>Tämän sivun koodit löytyvät Linkin GitHubista.

--- a/data/fi/carousel/uudet-sivut.yaml
+++ b/data/fi/carousel/uudet-sivut.yaml
@@ -1,9 +1,6 @@
 weight: 1
-title: "Linkin uudet kotisivut"
+title: "Linkin kotisivut"
 description: >
-  <p>Tervetuloa!<br/>
-  <br/>
-  Kaikkea palautetta sivusta arvostetaan.
-  <a href="/hallitus/2024#webmaster">Yhdistyksen webmaster</a> osaa ohjata sen verkkosivutiimille.</p>
+  <p>Linkki Jyväskylä ry on vuonna 2006 perustettu tietotekniikan, tietojenkäsittelytieteen ja koulutusteknologian ainejärjestö.</p>
 image: "img/linkki.svg"
 #href: "/"

--- a/data/fi/carousel/ytp.yaml
+++ b/data/fi/carousel/ytp.yaml
@@ -1,0 +1,8 @@
+weight: 10
+title: "ATK-YTP 2024"
+description: >
+  <p>ATK-yhteistoimintapäivät täyttävät Jyväskylän pian tietotekniikan opiskelijoista ympäri Suomen.
+  <br/><br/>
+  🌴 zyn zyn zyn 🌴</p>
+image: "/img/atk-ytp-2024.webp"
+href: "https://atk-ytp.org"

--- a/static/img/atk-ytp-2024.webp
+++ b/static/img/atk-ytp-2024.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8937519e4f8815df2202d65dc8452c41568ea31d457297d64227f222c951a545
+size 20012

--- a/static/img/linkkiukkeli-perus-istuu.webp
+++ b/static/img/linkkiukkeli-perus-istuu.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e792f89a73635edafa0e0cc7b49f3d1a3da0cc7e892e251eaa84660f8ae423f4
-size 32486
+oid sha256:272b672716942250e8504dc9e532ff76ccd61ef830dfee30ec1ef541456c9f08
+size 11538


### PR DESCRIPTION
Carousel updates:
- Hid freshmen from carousel
- Moved main page information to carousel
- ATK-YTP 2024

Any thoughts on moving information about Linkki to carousel? I think it simplifies the page in a pleasant way.