### PR TITLE
fixed footer säännöt link

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -365,7 +365,7 @@ home = ["html", "rss", "api-sponsors"]
                 <strong>Tietosuojaseloste</strong>
             </a>
             <br/>
-            <a class="text-uppercase" href="/yhdistys/säännöt/">
+            <a class="text-uppercase" href="/säännöt/">
                 <strong>Säännöt</strong>
             </a>
     """


### PR DESCRIPTION
fixes https://github.com/Linkkijkl/linkki-web/issues/226

footer linkki ohjaa nyt oikeaan paikkaan eli [https://linkkijkl.fi/säännöt/](https://linkkijkl.fi/s%C3%A4%C3%A4nn%C3%B6t/)