### PR TITLE
add JYY as sponsor

### DIFF
--- a/data/clients/jyy.yaml
+++ b/data/clients/jyy.yaml
@@ -1,0 +1,4 @@
+name: "Jyväskylän ylioppilaskunta"
+image: "/img/clients/jyylogo.png"
+url: "https://jyy.fi/"
+dark: true

--- a/static/img/clients/jyylogo.png
+++ b/static/img/clients/jyylogo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a9242e6c11a824ec13ff0dd2b03fd2293846e82c44c8a271c40270add521037
+size 51457


### PR DESCRIPTION
fixes #242 

Nahkalilja on partiolaisten suoritusmerkki.

Nahkalilja on noin tuuman korkuinen, 1 mm vahvuisesta nahasta valmistettu partiolilja, joka on tarkoitettu kiinnitettäväksi [partio- tai eräpojan vyöhön](https://fi.wikipedia.org/wiki/Partiovy%C3%B6). Liljoja on kolmea astetta: Punainen, Vihreä ja Harmaa. Seuraavan asteen suorittamiseen on edellytyksenä on, että edellinen aste on suoritettu.