### PR TITLE
fix: copyright year in footer and add translation for "All the rights reserved"

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -123,3 +123,6 @@
 
 - id: invoicing
   translation: Invoicing
+
+- id: allRightsReserved
+  translation: "All rights reserved"

--- a/i18n/fi.yaml
+++ b/i18n/fi.yaml
@@ -123,3 +123,6 @@
 
 - id: invoicing
   translation: Laskutus
+
+- id: allRightsReserved
+  translation: "Kaikki oikeudet pidätetään"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -87,7 +87,7 @@ _________________________________________________________ -->
     <div class="container">
         <div class="col-md-12">
             {{ if isset .Site.Params "copyright" }}
-            <p class="pull-left">{{ .Site.Params.copyright | safeHTML }}</p>
+            <p class="pull-left">Copyright &copy; {{ now.Year }} Linkki Jyväskylä ry. {{ i18n "allRightsReserved" }}.</p>
             {{ end }}
             <p class="pull-right">
               {{ i18n "templateBy" | markdownify }} <a href="https://bootstrapious.com/p/universal-business-e-commerce-template">Bootstrapious</a>.


### PR DESCRIPTION
Fixes #270

****Screetshot**:

For English:
![Image](https://github.com/user-attachments/assets/19432818-d2ff-447d-b6d1-9c11d2f65900)

For Finnish:

![Image](https://github.com/user-attachments/assets/b11a510d-faf8-41b6-802c-718864cdf4b8)**