### PR TITLE
remove prefetching unused domain

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -384,9 +384,6 @@ home = ["html", "rss", "api-sponsors"]
 
     modified_by_url = "https://github.com/linkkijkl/linkki-web/graphs/contributors"
 
-    # Prefetch theese domains from DNS
-    prefetch_domains = ["kattila.cafe"]
-
 
 [languages.fi.params]
     about_us = """

--- a/hugo.toml
+++ b/hugo.toml
@@ -384,6 +384,9 @@ home = ["html", "rss", "api-sponsors"]
 
     modified_by_url = "https://github.com/linkkijkl/linkki-web/graphs/contributors"
 
+    # Prefetch theese domains from DNS
+    prefetch_domains = ["kattila.linkkijkl.fi"]
+
 
 [languages.fi.params]
     about_us = """


### PR DESCRIPTION
kattila coffee camera is no longer located at kattila.cafe, so we shouldn't have anything to do with it anymore :]