### PR TITLE
add translations to freshers page, other minor changes

### DIFF
--- a/content/toiminta/fuksit.en.md
+++ b/content/toiminta/fuksit.en.md
@@ -1,0 +1,46 @@
++++
+title = "New students' (freshers) guide"
+description = ""
+keywords = ["fuksit"]
+url = "fuksit"
++++
+
+Warm welcome to Jyväskylä!
+Aside official guides and this page you can familiarize yourself
+with [an alternative study guide for STEM students](https://www.jyu.fi/fi/file/vopas2024), known as VOpas. This document is soon partially out of date, and is written entirely in Finnish.
+
+> "VOpas is perhaps the most significant – in any case most successful book,
+> that Jyväskylän University's STEM faculty
+> has ever published. Even though it contains encertainties,
+> old-fashionednesses and full-on contradictions, it
+> has provided an irreprodicble aid in new students'
+> lives, who are thrown amidst higher education while
+> while fumbling the very threads of their lives."
+
+## Brief reminders
+
+**Remember**:
+
+- if you are eligible pay the FSHS-payment and apply for social benefits in [OmaKela](https://oma.kela.fi/)
+- apply for student accomodation from [KOAS](https://www.koas.fi/) or
+[Soihtu](https://soihtu.fi/asuminen/)
+- apply for a student ID ([Frank](https://www.frank.fi/)/[Slice](https://slice.fi/fi)/[Kide.app](https://kide.app/student-card)/[Pivo](https://pivo.fi/palvelut/opiskelijakortti/)/[physical](https://www.frank.fi/opiskelijakortti/))
+
+## In the beginning
+
+Your studies will begin in late August with a roll call in
+[Agora](https://www.openstreetmap.org/way/87950403).
+The week following this is the so-called orientation week
+filled with JYU's, as well as student organistions' activities
+specifically to assimilate you into the world of academia.
+
+## What student association?
+
+Student associations are organisations comprised of each science's students, advocate for [student's rights](https://www.jyu.fi/en/for-students/instructions-for-bachelors-and-masters-students/new-student-handbook/students-rights-and-responsibilities), organise various
+culture, worklife and recreational events as well as work to improve the field of study's communality and employment.
+
+Linkki Jyväskylä ry (better known as Linkki) is the very own
+advocacy and recreational association for Bachelor's, Master's, and Doctoral students, who are studying
+Computer Science, Mathematical Information Technology and Education Technology in any capacity. Joining Linkki is free of charge, and joining provides you access to advocacy, events, [discounts from our partners](/en/benefits/).
+with the Linkki-sticker, as well as free coffee in [kattila](/kattila/).
+The link to the application form can be found on [the front page](/).

--- a/content/toiminta/fuksit.md
+++ b/content/toiminta/fuksit.md
@@ -20,6 +20,7 @@ Esimerkiksi Linkin tutorien esittelyt löydät VOppaasta.
 ## Lyhyt muistilista
 
 **Muistakaa**:
+
 - ottaa opiskelupaikka vastaan ja ilmoittautua läsnäolevaksi
 [Opintopolussa](https://opintopolku.fi)
 - maksaa YTHS-maksu ja hakea tukia [OmaKelassa](https://oma.kela.fi/)
@@ -34,19 +35,19 @@ Opintosi alkavat elokuun lopussa nimenhuutotilaisuudella
 Tätä seuraava nk. orientaatioviikko on täynnä
 sekä yliopiston, että ainejärjestön järjestämää ohjelmaa, jonka
 tarkoituksena on tutustuttaa juuri Sinut, uusi opiskelija,
-akateemiseen maailmaan. 
+akateemiseen maailmaan.
 
 ## Mikä ainejärjestö?
 
 Ainejärjestöt ovat kunkin oppiaineen opiskelijoista koostuvia
 yhdistyksiä, jotka tekevät edunvalvontaa, järjestävät erilaisia
 kulttuuri-, työelämä- ja huvitapahtumia sekä edistävät oppiaineen
-opiskelijoiden yhteisöllisyyttä ja työllistymistä. 
+opiskelijoiden yhteisöllisyyttä ja työllistymistä.
 
 Linkki Jyväskylä ry (tuttavallisemmin Linkki) on
 tietojenkäsittelytieteen, tietotekniikan sekä koulutusteknologian
 pääaine-, sivuaine- ja jatko-opiskelijoiden ikioma
 ainejärjestö. Linkkiin liittyminen on ilmaista ja liittymällä saat
-edunvalvontaa, tapahtumia, [alennuksia yhteistyökumppaneilta](/jäsenyys/#jäsenedut)
+edunvalvontaa, tapahtumia, [alennuksia yhteistyökumppaneilta](/jäsenedut/)
 Linkki-tarralla sekä maksutonta kahvia [Kattilassa](/kattila/).
 Linkin hakulomakkeeseen löydät [etusivulta](/).

--- a/hugo.toml
+++ b/hugo.toml
@@ -268,7 +268,7 @@ home = ["html", "rss", "api-sponsors"]
 
 
 [[languages.en.menus.main]]
-    name = "Activities"
+    name = "Activity"
     identifier = "menu.toiminta"
     weight = 2
 
@@ -328,6 +328,14 @@ home = ["html", "rss", "api-sponsors"]
 
 
 [[languages.en.menus.main]]
+    name = "New Students"
+    identifier = "menu.fuksit"
+    url = "/en/fuksit/"
+    parent = "menu.toiminta"
+    weight = 7
+
+
+[[languages.en.menus.main]]
     name = "Collaboration"
     identifier = "menu.yhteistyö"
     url = "/en/collaboration/"
@@ -354,7 +362,7 @@ home = ["html", "rss", "api-sponsors"]
     style = "blue"
     mainSections = ["blog", "a-href", "hallitus"]
 
-    
+
     defaultKeywords = ["linkkijkl", "linkki", "jyväskylä"]
 
     address = """
@@ -379,7 +387,7 @@ home = ["html", "rss", "api-sponsors"]
     # Format dates with Go's time formatting
     # https://pkg.go.dev/time
     date_format = "2.1.2006"
-    
+
     dropdown_mouse_over = false
 
     modified_by_url = "https://github.com/linkkijkl/linkki-web/graphs/contributors"


### PR DESCRIPTION
resolves #252
if I'm not mistaken, since @ikaros02 wasn't too clear in their issue
also the Finnish fresher page linked to the wrong page when referring to membership benefits, fixed that.
also saw fit to rename our navbar entry from activities to activity, it just makes sense.