### PR TITLE
fix public matrix chat address

### DIFF
--- a/content/toiminta/keskustelukanavat.en.md
+++ b/content/toiminta/keskustelukanavat.en.md
@@ -15,7 +15,7 @@ you can join from the platform you prefer. Our current channels are
 located in:
 
 - **Telegram**: @linkkijkl
-- **Matrix**: #linkkijkl:hacklab.fi
+- **Matrix**: #linkki:hacklab.fi
 - **IRC**: #linkki.jkl IRCnetissä
 - **Discord**: https://discord.com/invite/f9c6y97
 

--- a/content/toiminta/keskustelukanavat.md
+++ b/content/toiminta/keskustelukanavat.md
@@ -17,7 +17,7 @@ kanssa, eli keskusteluun voi osallistua haluamaltaan
 alustalta. Keskustelu on sillattuna seuraaviin palveluihin:
 
 - **Telegram**: @linkkijkl
-- **Matrix**: #linkkijkl:hacklab.fi
+- **Matrix**: #linkki:hacklab.fi
 - **IRC**: #linkki.jkl IRCnetissä
 - **Discord**: https://discord.com/invite/f9c6y97
 


### PR DESCRIPTION
apparently #linkkijkl:hacklab.fi is only visible within hacklab's server while #linkki:hacklab.fi is visible to entire matrix network