### PR TITLE
hotfix: match alpine image and package repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine AS builder
+FROM alpine:edge AS builder
 RUN apk update && apk add hugo npm
 RUN apk add dart-sass --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing
 # Install pagefind


### PR DESCRIPTION
Fixes occasional issues with dart-sass not matching the stable alpine release.
Using the alpine:edge image may introduce new problems!!