### PR TITLE
Revert "style: center search bar"

### DIFF
--- a/assets/sass/search.scss
+++ b/assets/sass/search.scss
@@ -15,8 +15,6 @@
 }
 
 .pagefind-ui {
-    display: flex;
-    align-items: center;
     position: relative;
     flex-grow: 1;
 }


### PR DESCRIPTION
Reverts Linkkijkl/linkki-web#340

PR introduced broken search positioning, and is hence to be reverted.