### PR TITLE
adding Mikael Garam as cloud coordinator

### DIFF
--- a/content/hallitus/2026/index.en.md
+++ b/content/hallitus/2026/index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "Board of Directors 2026"
 date = "2026-01-01T00:00:00+02:00"
-authors = ["Johannes Horila", "Jenna Tykkyläinen", "Ilkka Sario", "Lari Nurkka", "Olavi Lahtinen", "Anton Turpeinen", "Santeri Sormunen", "Lauri Leppänen", "Joonas Niemi", "Juho Ropanen", "Mortti Luhtala", "Oskari Lahtinen", "Valtteri Hiltunen", "Urho Laurinen", "Emma Järvinen", "Taru Nikkanen", "Aino Sipola", "Antton Kharine", "Eetu Norta", "Nico Kääriäinen", "Lassi Jääskeläinen", "Toni Pietiläinen", "Lassi Karjalainen"]
+authors = ["Johannes Horila", "Jenna Tykkyläinen", "Ilkka Sario", "Lari Nurkka", "Olavi Lahtinen", "Anton Turpeinen", "Santeri Sormunen", "Lauri Leppänen", "Joonas Niemi", "Juho Ropanen", "Mortti Luhtala", "Oskari Lahtinen", "Valtteri Hiltunen", "Urho Laurinen", "Emma Järvinen", "Taru Nikkanen", "Aino Sipola", "Antton Kharine", "Eetu Norta", "Nico Kääriäinen", "Lassi Jääskeläinen", "Toni Pietiläinen", "Lassi Karjalainen", "Mikael Garam"]
 banner = "/img/hallitukset/hallitus2026.webp"
 summary = " "
 url = "board/2026"
@@ -296,6 +296,15 @@ url = "board/2026"
 [**some@linkkijkl.fi**](mailto:some@linkkijkl.fi)
 
 [Telegram: **@taruksn**](https://t.me/taruksn)
+{{< /img-thumb-cap >}}
+{{< /column >}}
+
+{{< column >}}
+{{< img-thumb-cap "placeholder.png" "200x" >}}
+## Mikael Garam
+#### Cloud Coordinator
+
+[Telegram: **@michgfi**](https://t.me/michgfi)
 {{< /img-thumb-cap >}}
 {{< /column >}}
 

--- a/content/hallitus/2026/index.md
+++ b/content/hallitus/2026/index.md
@@ -3,7 +3,7 @@ title = "Hallitus 2026"
 date = "2026-01-01T00:00:00+02:00"
 description = "Linkin hallitus 2026"
 categories = ["hallitukset"]
-authors = ["Johannes Horila", "Jenna Tykkyläinen", "Ilkka Sario", "Lari Nurkka", "Olavi Lahtinen", "Anton Turpeinen", "Santeri Sormunen", "Lauri Leppänen", "Joonas Niemi", "Juho Ropanen", "Mortti Luhtala", "Oskari Lahtinen", "Valtteri Hiltunen", "Urho Laurinen", "Emma Järvinen", "Taru Nikkanen", "Aino Sipola", "Antton Kharine", "Eetu Norta", "Nico Kääriäinen", "Lassi Jääskeläinen", "Toni Pietiläinen", "Lassi Karjalainen"]
+authors = ["Johannes Horila", "Jenna Tykkyläinen", "Ilkka Sario", "Lari Nurkka", "Olavi Lahtinen", "Anton Turpeinen", "Santeri Sormunen", "Lauri Leppänen", "Joonas Niemi", "Juho Ropanen", "Mortti Luhtala", "Oskari Lahtinen", "Valtteri Hiltunen", "Urho Laurinen", "Emma Järvinen", "Taru Nikkanen", "Aino Sipola", "Antton Kharine", "Eetu Norta", "Nico Kääriäinen", "Lassi Jääskeläinen", "Toni Pietiläinen", "Lassi Karjalainen", "Mikael Garam"]
 banner = "/img/hallitukset/hallitus2026.webp"
 summary = " "
 +++
@@ -307,6 +307,15 @@ Mediatiimin tehtävänä on tiedottaa jäsenistöä yhdistyksen eri kanavissa ku
 [**some@linkkijkl.fi**](mailto:some@linkkijkl.fi)
 
 [Telegram: **@taruksn**](https://t.me/taruksn)
+{{< /img-thumb-cap >}}
+{{< /column >}}
+
+{{< column >}}
+{{< img-thumb-cap "placeholder.png" "200x" >}}
+## Mikael Garam
+#### Pilvivastaava
+
+[Telegram: **@michgfi**](https://t.me/michgfi)
 {{< /img-thumb-cap >}}
 {{< /column >}}
 


### PR DESCRIPTION
Adding me (Mikael Garam) as cloud coordinator in the media team on the board of directors 2026.
in Finnish and English